### PR TITLE
refactor to a bit tighter css, use built in bootstrap image styles

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -18,10 +18,8 @@ $display-font-weight: 500;
 
 /* Brew Card */
 
-.card img.recipe-img {
+.card .card-img-top {
   object-fit: cover;
-  object-position: center;
-  width: 100%;
   max-height: 15rem;
 }
 

--- a/lib/brew_dash_web/live/brew_card_component.html.leex
+++ b/lib/brew_dash_web/live/brew_card_component.html.leex
@@ -1,6 +1,6 @@
 <div class="column">
   <div class="card" style="width: 22rem;">
-    <img class="card-img-top recipe-img" src="<%= image_url(@brew) %>" alt="Recipe picture" />
+    <img class="card-img-top img-fluid" src="<%= image_url(@brew) %>" alt="Recipe picture" />
 
     <div class="card-body">
       <h1 class="card-title display-5 text-end">


### PR DESCRIPTION
Without overrides (shows full image, even worse looking with larger images):
<img width="358" alt="image" src="https://user-images.githubusercontent.com/244021/123291084-a3b39300-d4c6-11eb-874d-23a41c85d84c.png">


So cards look like:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/244021/123290956-88488800-d4c6-11eb-86f6-b530521c3cd2.png">
