### PR TITLE
centre cards

### DIFF
--- a/lib/brew_dash_web/live/brew_card_component.html.leex
+++ b/lib/brew_dash_web/live/brew_card_component.html.leex
@@ -1,4 +1,4 @@
-<div class="card" style="width: 22rem;">
+<div class="card mx-auto" style="width: 22rem;">
   <img class="card-img-top img-fluid" src="<%= image_url(@brew) %>" alt="Recipe picture" />
 
   <div class="card-body">


### PR DESCRIPTION
Mostly this is for narrower desktop windows, cards would float left in the cell before. This centres them nicely.