### PR TITLE
Fix BrewEditLive save updates @brew

### DIFF
--- a/lib/brew_dash_web/live/admin/brew_edit_live.ex
+++ b/lib/brew_dash_web/live/admin/brew_edit_live.ex
@@ -28,9 +28,9 @@ defmodule BrewDashWeb.Admin.BrewEditLive do
   end
 
   def handle_event("save", %{"brew" => brew}, socket) do
-    Brew.update!(socket.assigns.brew, brew)
+    brew = Brew.update!(socket.assigns.brew, brew)
     BrewDash.Sync.broadcast(:brew_sessions, :brew_sessions_updated)
-    {:noreply, socket}
+    {:noreply, assign(socket, brew: brew)}
   end
 
   defp fetch_brew_session(socket, params) do


### PR DESCRIPTION
The :brew assigns was not being set, so values that where set could not be returned to their origional values.