### PR TITLE
Add case for sorting when a tap number is nil

### DIFF
--- a/lib/brew_dash_web/live/dashboard_live.ex
+++ b/lib/brew_dash_web/live/dashboard_live.ex
@@ -50,6 +50,7 @@ defmodule BrewDashWeb.DashboardLive do
     end
   end
 
+  defp brew_sort_tap_number(b1, _) when is_binary(b1.tap_number), do: true
   defp brew_sort_tap_number(_b1, _b2), do: false
 
   defp append_new_sessions(sessions) when length(sessions) < @displayable_sessions do


### PR DESCRIPTION
It is possible to mis sort if one of the conditioning or on tap "tap_number" is nil, this accounts for that and fixes the sorting

ala:

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/244021/161356597-926704e6-fd8c-4632-841d-a072233f93aa.png">
