### PR TITLE
hide scrollbar on dashboard

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -1,5 +1,7 @@
 // See the Tailwind configuration guide for advanced usage
 // https://tailwindcss.com/docs/configuration
+const plugin = require('tailwindcss/plugin');
+
 module.exports = {
   content: [
     './js/**/*.js',
@@ -18,7 +20,36 @@ module.exports = {
     }
   },
   plugins: [
-    require('@tailwindcss/forms')
+    require('@tailwindcss/forms'),
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        '.scrollbar-hide': {
+          /* IE and Edge */
+          '-ms-overflow-style': 'none',
+
+          /* Safari and Chrome */
+          '&::-webkit-scrollbar': {
+            display: 'none'
+          },
+
+          /* Firefox */
+          'scrollbar-width': 'none'
+        },
+
+        '.scrollbar-default': {
+          /* IE and Edge */
+          '-ms-overflow-style': 'auto',
+
+          /* Firefox */
+          'scrollbar-width': 'auto',
+
+          /* Safari and Chrome */
+          '&::-webkit-scrollbar': {
+            display: 'block'
+          }
+        }
+      }, ['responsive'])
+    })
   ],
   darkMode: 'class'
 }

--- a/lib/brew_dash_web/templates/layout/root.html.heex
+++ b/lib/brew_dash_web/templates/layout/root.html.heex
@@ -7,7 +7,7 @@
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")}/>
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
   </head>
-  <body class="dark:bg-black dark:text-white">
+  <body class="dark:bg-black dark:text-white scrollbar-hide">
     <%= @inner_content %>
   </body>
 </html>


### PR DESCRIPTION
Some brew card info could exceed the displayable area and cause a scrollbar to appear on chrome.

- Add tailwind config for new scrollbar classes