### PR TITLE
make the taps dashboard responsive

### DIFF
--- a/lib/brew_dash_web/live/taps_dashboard_live.html.heex
+++ b/lib/brew_dash_web/live/taps_dashboard_live.html.heex
@@ -1,4 +1,4 @@
-<div class="p-4 grid grid-cols-4 justify-items-center gap-16">
+<div class="grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-4 justify-items-center p-4 gap-16">
   <%= for brew <- @brew_sessions do %>
     <.live_component module={BrewDashWeb.BrewCardComponent} id={brew.id} brew={brew} />
   <% end %>


### PR DESCRIPTION
Specifically make it viewable on a phone!


Medium screen
<img width="902" alt="Screen Shot 2022-06-06 at 10 52 28" src="https://user-images.githubusercontent.com/244021/172217423-bc9c1544-14ad-43ff-85d8-1c3ace869e7d.png">


Small screen
<img width="624" alt="Screen Shot 2022-06-06 at 10 52 34" src="https://user-images.githubusercontent.com/244021/172217449-0b1927de-df8c-49f2-a2da-2a0a57fb9cf6.png">

